### PR TITLE
extend and clean up defmulti examples

### DIFF
--- a/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/1034465836.clj
+++ b/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/1034465836.clj
@@ -1,4 +1,15 @@
-(defmulti service-charge (fn [acct] [(account-level acct) (:tag acct)]))
-(defmethod service-charge [::acc/Basic ::acc/Checking]   [_] 25)
-(defmethod service-charge [::acc/Basic ::acc/Savings]    [_] 10)
-(defmethod service-charge [::acc/Premium ::acc/Account] [_] 0)
+;; using multiple functions of the input and a derived key for dispatch
+
+(defmulti service-charge (juxt :account-level :tag))
+
+(derive ::Savings ::Account)
+(derive ::Checking ::Account)
+
+(defmethod service-charge [::Basic ::Checking]  [_] 25)
+(defmethod service-charge [::Basic ::Savings]   [_] 10)
+(defmethod service-charge [::Premium ::Account] [_] 0)
+
+(service-charge {:account-level ::Basic, :tag ::Savings, :balance 1000.01M})
+;; => 10
+(service-charge {:account-level ::Premium, :tag ::Savings, :balance 1000.01M})
+;; => 0

--- a/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/117314876.clj
+++ b/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/117314876.clj
@@ -6,10 +6,15 @@
 (defmulti factorial identity)
 
 (defmethod factorial 0 [_]  1)
+
 (defmethod factorial :default [num] 
     (* num (factorial (dec num))))
 
-(factorial 0) ; => 1
-(factorial 1) ; => 1
-(factorial 3) ; => 6
-(factorial 7) ; => 5040
+(factorial 0)
+;; => 1
+(factorial 1)
+;; => 1
+(factorial 3)
+;; => 6
+(factorial 7)
+;; => 5040

--- a/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/619411383.clj
+++ b/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/619411383.clj
@@ -1,5 +1,5 @@
-;this example illustrates that the dispatch type
-;does not have to be a symbol, but can be anything (in this case, it's a string)
+;; this example illustrates that the dispatch type does not have to be a
+;; keyword, but can be anything (in this case, it's a string)
 
 (defmulti greeting
   (fn[x] (x "language")))
@@ -21,9 +21,9 @@
 (def  french-map {"id" "2", "language" "French"})
 (def spanish-map {"id" "3", "language" "Spanish"})
 
-=>(greeting english-map)
-"Hello!"
-=>(greeting french-map)
-"Bounjour!"
-=>(greeting spanish-map)
- java.lang.IllegalArgumentException: I don't know the Spanish language
+(greeting english-map)
+;; => "Hello!"
+(greeting french-map)
+;; => "Bounjour!"
+(greeting spanish-map)
+;; => java.lang.IllegalArgumentException: I don't know the Spanish language

--- a/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/justin_smith-defmulti-defonce.clj
+++ b/org.clojure/clojure/1.4.0/clj/clojure.core/defmulti/examples/justin_smith-defmulti-defonce.clj
@@ -1,0 +1,52 @@
+;; defmulti has defonce semantics, meaning that it will not be evaluated if
+;; the specified multi has a non-nil binding already.
+
+;; this example also demonstrates a defmulti with more than one argument
+
+(defmulti speak identity)
+;; => #'user/speak
+(defmethod speak :cow [_] "MOO")
+;; => #<MultiFn clojure.lang.MultiFn@2ac20952>
+(speak :cow)
+;; => "MOO"
+(defmethod speak :cat [_] "PURR")
+;; => #<MultiFn clojure.lang.MultiFn@2ac20952>
+(speak :cat)
+;; => "PURR"
+
+;; what if we want the cat to be able to meow too?
+
+(defmulti speak (fn [animal mood] animal))
+;; => nil
+(defmethod speak :cat [_ mood] (get {:happy "PURR" :hungry "MEOW"} mood))
+;; => #<MultiFn clojure.lang.MultiFn@2ac20952>
+(speak :cat :happy)
+;; => ArityException Wrong number of args (2) passed to: core/identity  clojure.lang.AFn.throwArity (AFn.java:429)
+
+;;; the original dispatch has not been replaced!
+
+(def speak nil) ; destroy our defmulti explicitly
+;; => #'user/speak
+(defmulti speak (fn [animal mood] animal))
+;; => #'user/speak
+(defmethod speak :cat [_ mood] (get {:happy "PURR" :hungry "MEOW"} mood))
+;; => #<MultiFn clojure.lang.MultiFn@66668e94>
+(speak :cat :happy)
+;; => "PURR"
+(speak :cat :hungry)
+;; => "MEOW"
+
+;;; how about varargs, so our original cow can still work?
+
+(def speak nil) ; destroy our defmulti explicitly
+;;=> #'user/speak
+(defmulti speak (fn [animal & args] animal))
+;;=> #'user/speak
+(defmethod speak :cat [_ mood] (get {:happy "PURR" :hungry "MEOW"} mood))
+;;=> #<MultiFn clojure.lang.MultiFn@447536f2>
+(speak :cat :hungry)
+;;=> "MEOW"
+(defmethod speak :cow [_] "MOO")
+;; => #<MultiFn clojure.lang.MultiFn@447536f2>
+(speak :cow)
+;; => "MOO"


### PR DESCRIPTION
This includes making the formatting more consistent between examples, fixing a typo in the language example (keyword rather than symbol), fixing the banking example so that it actually runs, and demonstrating the following features previously not demonstrated:

changing a defmulti

defmulti with more than 1 arg

defmulti with varargs

using derive to facilitate dispatch
