### PR TITLE
Update 2087965203.clj

### DIFF
--- a/org.clojure/clojure/1.4.0/clj/clojure.core/fn/examples/2087965203.clj
+++ b/org.clojure/clojure/1.4.0/clj/clojure.core/fn/examples/2087965203.clj
@@ -1,5 +1,6 @@
-;; the shortcut form for (fn ) is #( )
+;; the shortcut form for (fn [arg1 arg2 ...] (...)) is #(...)
 ;; where parameters are referred by their index with the prefix %
+;; and the number of argN depends on how many %N you have in the body
 
 ;; the equivalent of 
 ((fn [a b c] (+ a b c)) 2 4 6)


### PR DESCRIPTION
Previous definition was unclear since it did not include the inner evaluating parens.
Source: http://stackoverflow.com/a/13205141/4250752
