### PR TITLE
Add notes on condp

### DIFF
--- a/org.clojure/clojure/1.4.0/clj/clojure.core/condp/notes.md
+++ b/org.clojure/clojure/1.4.0/clj/clojure.core/condp/notes.md
@@ -1,0 +1,21 @@
+## Arities
+
+    [pred expr & clauses]
+
+## Docstring
+
+Takes a binary predicate, an expression, and a set of clauses. Each
+clause can take the form of either:
+
+    test-expr result-expr
+    test-expr :>> result-fn
+
+For each clause, `(pred test-expr expr)` is evaluated. If it returns
+logical true, the clause is said to be a match. If a binary clause
+matches, the `result-expr` is returned, if a ternary clause matches,
+its `result-fn`, which must be a unary function, is called with the
+result of the predicate as its argument, the result of that call being
+the return value of condp. A single default expression can follow the
+clauses, and its value will be returned if no clause matches. If no
+default expression is provided and no clause matches, an
+`IllegalArgumentException` is thrown.


### PR DESCRIPTION
Note that I dropped the `:>>` notes from the source docstring since
the fact that `:>>` has no special reader semantics is pretty much
meaningless especially since it does have evaluation semantics in that
the condp macro does test for equality against exactly that keyword.
